### PR TITLE
Small changes to parse_gct, parse_gctx, and parse

### DIFF
--- a/cmapPy/pandasGEXpress/concat_gctoo.py
+++ b/cmapPy/pandasGEXpress/concat_gctoo.py
@@ -280,8 +280,8 @@ def assemble_common_meta(common_meta_dfs, fields_to_remove):
 
     else:
         all_meta_df_with_dups["concat_gctoo_column_for_index"] = all_meta_df_with_dups.index
-        all_meta_df = all_meta_df_with_dups.drop_duplicates()
-	all_meta_df.drop("concat_gctoo_column_for_index", axis=1, inplace=True)
+        all_meta_df = all_meta_df_with_dups.copy(deep=True).drop_duplicates()
+        all_meta_df.drop("concat_gctoo_column_for_index", axis=1, inplace=True)
 
     logger.debug("all_meta_df_with_dups.shape: {}".format(all_meta_df_with_dups.shape))
     logger.debug("all_meta_df.shape: {}".format(all_meta_df.shape))

--- a/cmapPy/pandasGEXpress/parse.py
+++ b/cmapPy/pandasGEXpress/parse.py
@@ -50,7 +50,12 @@ def parse(file_path, convert_neg_666=True, rid=None, cid=None, ridx=None, cidx=N
 		into numpy.NaN values, the pandas default. 
 	""" 
 	if file_path.endswith(".gct"):
-		curr = parse_gct.parse(file_path, convert_neg_666, rid, cid, make_multiindex)
+		# Ignoring arguments that won't be passed to parse_gct
+		for unused_arg in ["rid", "cid", "cidx", "row_meta_only", "col_meta_only"]:
+			if eval(unused_arg) is not None:
+				msg = "parse_gct does not use the argument {}. Ignoring it...".format(unused_arg)
+				logger.info(msg)
+		curr = parse_gct.parse(file_path, convert_neg_666, make_multiindex)
 	elif file_path.endswith(".gctx"):
 		curr = parse_gctx.parse(file_path, convert_neg_666, rid, cid, ridx, cidx, row_meta_only, col_meta_only, make_multiindex)
 	else:

--- a/cmapPy/pandasGEXpress/parse_gct.py
+++ b/cmapPy/pandasGEXpress/parse_gct.py
@@ -79,15 +79,13 @@ column_header_name = "chd"
 DATA_TYPE = np.float32
 
 
-def parse(file_path, convert_neg_666=True, rid=None, cid=None, make_multiindex=False):
+def parse(file_path, convert_neg_666=True, make_multiindex=False):
     """ The main method.
 
     Args:
         - file_path (string): full path to gct(x) file you want to parse
         - convert_neg_666 (bool): whether to convert -666 values to numpy.nan
             (see Note below for more details). Default = True.
-        - rid (list of strings): list of row ids to specifically keep  None keeps all rids
-        - cid (list of strings): list of col ids to specifically keep, None keeps all cids
         - make_multiindex (bool): whether to create a multi-index df combining
             the 3 component dfs
 
@@ -101,18 +99,9 @@ def parse(file_path, convert_neg_666=True, rid=None, cid=None, make_multiindex=F
         into numpy.nan values, the pandas default.
 
     """
-    # Throw error if user attempts to slice
-    if (rid is not None) or (cid is not None):
-        error_msg = ("Slicing is not available through parse for .gct files; if you'd like to slice, " +
-            "please parse the entire file in (you have to do this anyway!) and then use methods from " + 
-            "the slice_gct module.")
-        logger.error(error_msg)
-        raise(Exception(error_msg))
-
-
     nan_values = [
         "#N/A", "N/A", "NA", "#NA", "NULL", "NaN", "-NaN",
-        "nan", "-nan", "#N/A!", "na", "NA", "None"]
+        "nan", "-nan", "#N/A!", "na", "NA", "None", "#VALUE!"]
 
     # Add "-666" to the list of NaN values
     if convert_neg_666:

--- a/cmapPy/pandasGEXpress/parse_gctx.py
+++ b/cmapPy/pandasGEXpress/parse_gctx.py
@@ -53,7 +53,15 @@ def parse(gctx_file_path, convert_neg_666=True, rid=None, cid=None,
 		into numpy.NaN values, the pandas default. 
 	"""
 	full_path = os.path.expanduser(gctx_file_path)
-	# open file 
+
+	# Verify that the  path exists
+	if not os.path.exists(full_path):
+		err_msg = "The given path to the gctx file cannot be found. full_path: {}"
+		logger.error(err_msg.format(full_path))
+		raise(Exception(err_msg.format(full_path)))
+	logger.info("Reading GCTX: {}".format(full_path))
+
+	# open file
 	gctx_file = h5py.File(full_path, "r")
 
 	if row_meta_only:


### PR DESCRIPTION
Two main changes:

- Making a copy of df in concat_gctoo to avoid warning
- Added #VALUE! as another value to consider NaN in parse_gct.py (request from proteomics crew)

While I was in there, I made a few minor changes:

- Previously, you could pass rid and cid as arguments to parse_gct, but then it would immediately break if you did; instead, I made it so that you can't even pass those args to parse_gct, but parse.py warns you that it will ignore those args (if parsing a GCT). I was thinking that errorring out is too severe.
- Added a check in parse_gctx to make sure that the file exists. This makes the error message a little nicer.

@dllahr, @oena Let me know if these sound good.