### PR TITLE
fix bug where floats where written out with maximum decimal places and data_float_parameter was ignored

### DIFF
--- a/cmapPy/pandasGEXpress/tests/test_write_gct.py
+++ b/cmapPy/pandasGEXpress/tests/test_write_gct.py
@@ -34,8 +34,8 @@ class TestWriteGct(unittest.TestCase):
             index=pd.Index(["cid1", "cid2", "cid3"], name="cid"),
             columns=pd.Index(["qc_iqr", "pert_idose", "pert_iname", "pert_itime"], name="chd"))
 
-    def test_main(self):
-        out_name = os.path.join(FUNCTIONAL_TESTS_PATH, "test_main_out.gct")
+    def test_write(self):
+        out_name = os.path.join(FUNCTIONAL_TESTS_PATH, "test_write_out.gct")
 
         gctoo = GCToo.GCToo(data_df=self.data_df,
                             row_metadata_df=self.row_metadata_df,
@@ -58,6 +58,30 @@ class TestWriteGct(unittest.TestCase):
         # Cleanup
         os.remove(out_name)
 
+    def test_write_gct(self):
+        out_name = os.path.join(FUNCTIONAL_TESTS_PATH, "test_write_gct_out.gct")
+
+        gctoo = GCToo.GCToo(data_df=self.data_df,
+                            row_metadata_df=self.row_metadata_df,
+                            col_metadata_df=self.col_metadata_df)
+        wg.write_gct(gctoo, out_name, data_null="NaN",
+                 metadata_null="-666", filler_null="-666")
+
+        # Read in the gct and verify that it's the same as gctoo
+        new_gct = pg.parse(out_name)
+
+        pd.util.testing.assert_frame_equal(new_gct.data_df, gctoo.data_df)
+        pd.util.testing.assert_frame_equal(new_gct.row_metadata_df, gctoo.row_metadata_df)
+        pd.util.testing.assert_frame_equal(new_gct.col_metadata_df, gctoo.col_metadata_df)
+
+        # Also check that missing values were written to the file as expected
+        in_df = pd.read_csv(out_name, sep="\t", skiprows=2, keep_default_na=False)
+        self.assertEqual(in_df.iloc[0, 1], "-666")
+        self.assertEqual(in_df.iloc[5, 6], "NaN")
+
+        # Cleanup
+        os.remove(out_name)
+   
     def test_write_version_and_dims(self):
         # Write
         fname = "test_file.gct"

--- a/cmapPy/pandasGEXpress/tests/test_write_gct.py
+++ b/cmapPy/pandasGEXpress/tests/test_write_gct.py
@@ -98,7 +98,7 @@ class TestWriteGct(unittest.TestCase):
         # Write
         fname = "test_write_bottom_half.tsv"
         f = open(fname, "wb")
-        wg.write_bottom_half(f, self.row_metadata_df, self.data_df, "NaN", "%.f", "-666")
+        wg.write_bottom_half(f, self.row_metadata_df, self.data_df, "NaN", "%.1f", "-666")
         f.close()
 
         # Compare what was written to what was expected
@@ -130,13 +130,15 @@ class TestWriteGct(unittest.TestCase):
         # Read in original gct file
         l1000_in_gct = pg.parse(l1000_in_path)
 
-        # Read in new gct file
+        # do write operation
         wg.write(l1000_in_gct, l1000_out_path)
+        
+        # Read in new gct file
         l1000_out_gct = pg.parse(l1000_out_path)
 
-        self.assertTrue(l1000_in_gct.data_df.equals(l1000_out_gct.data_df))
-        self.assertTrue(l1000_in_gct.row_metadata_df.equals(l1000_out_gct.row_metadata_df))
-        self.assertTrue(l1000_in_gct.col_metadata_df.equals(l1000_out_gct.col_metadata_df))
+        pd.util.testing.assert_frame_equal(l1000_in_gct.data_df, l1000_out_gct.data_df)
+        pd.util.testing.assert_frame_equal(l1000_in_gct.row_metadata_df, l1000_out_gct.row_metadata_df)
+        pd.util.testing.assert_frame_equal(l1000_in_gct.col_metadata_df, l1000_out_gct.col_metadata_df)
 
         # Clean up
         os.remove(l1000_out_path)
@@ -148,13 +150,15 @@ class TestWriteGct(unittest.TestCase):
         # Read in original gct file
         p100_in_gct = pg.parse(p100_in_path)
 
+        # do write operation - note data_float_format set to None to preserve precision of input file
+        wg.write(p100_in_gct, p100_out_path, data_float_format=None)
+        
         # Read in new gct file
-        wg.write(p100_in_gct, p100_out_path)
         p100_out_gct = pg.parse(p100_out_path)
 
-        self.assertTrue(p100_in_gct.data_df.equals(p100_out_gct.data_df))
-        self.assertTrue(p100_in_gct.row_metadata_df.equals(p100_out_gct.row_metadata_df))
-        self.assertTrue(p100_in_gct.col_metadata_df.equals(p100_out_gct.col_metadata_df))
+        pd.util.testing.assert_frame_equal(p100_in_gct.data_df, p100_out_gct.data_df)
+        pd.util.testing.assert_frame_equal(p100_in_gct.row_metadata_df, p100_out_gct.row_metadata_df)
+        pd.util.testing.assert_frame_equal(p100_in_gct.col_metadata_df, p100_out_gct.col_metadata_df)
 
         # Clean up
         os.remove(p100_out_path)

--- a/cmapPy/pandasGEXpress/write_gct.py
+++ b/cmapPy/pandasGEXpress/write_gct.py
@@ -20,8 +20,8 @@ def write_gct(gctoo, out_fname, data_null="NaN", metadata_null="-666",
 
     Included as a separate method for backwards compatibility.
     """
-    write(gctoo, out_fname, data_null="NaN", metadata_null="-666", 
-    filler_null="-666", data_float_format=":.4f")
+    write(gctoo, out_fname, data_null=data_null, metadata_null=metadata_null, 
+    filler_null=filler_null, data_float_format=data_float_format)
 
 def write(gctoo, out_fname, data_null="NaN", metadata_null="-666", filler_null="-666", data_float_format="%.4f"):
     """Write a gctoo object to a gct file.


### PR DESCRIPTION
Hello friends!  I noticed that when I was using `write_gct` the resulting text files were written out with the maximum number of decimal places (based on the float type used) and the `data_float_format` parameter was ignored.

Short version:  this pull request fixes that problem.

Long version:  `pandas.DataFrame.to_csv` was ignoring the `float_format` option because in the method `write_bottom_half` the dataframe that is written is entirely of type `object` - it only applies the `float_format` parameter to floats.  So I changed how we make that dataframe, keeping the left bottom half as type `object` and making the right bottom half exactly what the contents of `data_df` are.

EDIT:  Also I fixed a bug in write_gct.write_gct where it was ignoring all input arguments and using hard-coded ones in its call to write.  Might consider deleting write_gct since it is redundant?