### PR TITLE
Significant speed up in pandasGEXpress

### DIFF
--- a/cmapPy/pandasGEXpress/parse_gctx.py
+++ b/cmapPy/pandasGEXpress/parse_gctx.py
@@ -229,10 +229,12 @@ def get_ordered_idx(id_type, id_list, meta_df):
         if id_type is None:
             id_list = range(0, len(list(meta_df.index)))
         elif id_type == "id":
-            id_list = [list(meta_df.index).index(str(i)) for i in id_list]
+            lookup = {x: i for (i,x) in enumerate(meta_df.index)}
+            id_list = [lookup[str(i)] for i in id_list]
         return sorted(id_list)
     else:
         return None
+
 
 
 def parse_metadata_df(dim, meta_group, convert_neg_666):

--- a/cmapPy/pandasGEXpress/parse_gctx.py
+++ b/cmapPy/pandasGEXpress/parse_gctx.py
@@ -236,7 +236,6 @@ def get_ordered_idx(id_type, id_list, meta_df):
         return None
 
 
-
 def parse_metadata_df(dim, meta_group, convert_neg_666):
     """
     Reads in all metadata from .gctx file to pandas DataFrame


### PR DESCRIPTION
Calling pandasGEXpress with any number of cids is *very* slow - 
my machine takes about 24s for 1000 cids.

This is due to an unfortunate lookup method in get_ordered_idx(id_type, id_list, meta_df).
In essence, for each id the meta_df.index get's converted into a list, and then .index is called upon it.

This PR replaces it with a dictionary based lookup,
and I can load a 1000 cids in 1s und 10,000 in 2s.