### PR TITLE
Fix GCT file parsing in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 # python versioning
 python:
   - 2.7
-  - 3.7
+  - 3.6
 
 dist: xenial
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 language: python
 
-# python versioning 
+# python versioning
 python:
   - 2.7
+  - 3.7
 
 # requirements
-install: 
+install:
   - pip install -r requirements.txt
   - python setup.py develop
 
 # environments to use for tests (below)
-env: 
+env:
   - TEST_DIR=cmapPy/pandasGEXpress/tests
   - TEST_DIR=cmapPy/set_io/tests
   - TEST_DIR=cmapPy/math/tests
 
-# run all tests in each test dir 
+# run all tests in each test dir
 script: cd $TEST_DIR && python -m unittest discover -p "test_*.py"
 
 # what branches of github to use

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - 2.7
   - 3.7
 
+dist: xenial
+
+sudo: true
+
 # requirements
 install:
   - pip install -r requirements.txt

--- a/cmapPy/pandasGEXpress/parse_gct.py
+++ b/cmapPy/pandasGEXpress/parse_gct.py
@@ -62,6 +62,7 @@ import logging
 import pandas as pd
 import numpy as np
 import os.path
+import sys
 import cmapPy.pandasGEXpress.GCToo as GCToo
 import cmapPy.pandasGEXpress.subset_gctoo as sg
 import cmapPy.pandasGEXpress.setup_GCToo_logger as setup_logger
@@ -162,7 +163,11 @@ def parse(file_path, convert_neg_666=True, rid=None, cid=None,
 
 def read_version_and_dims(file_path):
     # Open file
-    f = open(file_path, "rb")
+    if sys.version_info[0] < 3:
+        f = open(file_path, "rb")
+    else:
+        # Python 3 expects "bytes" objects rather than str when opening with "rb"
+        f = open(file_path, "r")
 
     # Get version from the first line
     version = f.readline().strip().lstrip("#")


### PR DESCRIPTION
When trying to parse a GCT file using `cmapPy.pandasGEXpress.parse.parse()` in Python 3, the following error raises:

```
In [2]: x = parse('./ps_A375_n8471x8471.gct')
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-9ac756de3f82> in <module>()
----> 1 x = parse('./ps_A375_n8471x8471.gct')

~/developer/python/cmappy/cmapPy/pandasGEXpress/parse.py in parse(file_path, convert_neg_666, rid, cid, ridx, cidx, row_meta_only, col_meta_only, make_multiindex)
     60                               rid=rid, cid=cid, ridx=ridx, cidx=cidx,
     61                               row_meta_only=row_meta_only, col_meta_only=col_meta_only,
---> 62                               make_multiindex=make_multiindex)
     63
     64     elif file_path.endswith(".gctx"):

~/developer/python/cmappy/cmapPy/pandasGEXpress/parse_gct.py in parse(file_path, convert_neg_666, rid, cid, ridx, cidx, row_meta_only, col_meta_only, make_multiindex)
    134     # Read version and dimensions
    135     (version, num_data_rows, num_data_cols,
--> 136      num_row_metadata, num_col_metadata) = read_version_and_dims(file_path)
    137
    138     # Read in metadata and data

~/developer/python/cmappy/cmapPy/pandasGEXpress/parse_gct.py in read_version_and_dims(file_path)
    166
    167     # Get version from the first line
--> 168     version = f.readline().strip().lstrip("#")
    169
    170     if version not in ["1.3", "1.2"]:

TypeError: a bytes-like object is required, not 'str'
```

In Python 3, this error occurs when a file is read as binary (e.g., `open('foo.bar', "rb")` when it shouldn't be. This patch resolves the issue by testing the python version and using the correct flag within `open()`.