### PR TITLE
cmapPy/math/fast_corr.py and fast_cov.py:  update these routines so they can accept 1D arrays as inputs

### DIFF
--- a/cmapPy/math/fast_corr.py
+++ b/cmapPy/math/fast_corr.py
@@ -29,7 +29,12 @@ def fast_corr(x, y=None, destination=None):
     r = fast_cov.fast_cov(x, y, destination=destination)
 
     std_x = numpy.std(x, axis=0, ddof=1)
+    if numpy.isscalar(std_x):
+        std_x = numpy.array((std_x,))
+
     std_y = numpy.std(y, axis=0, ddof=1)
+    if numpy.isscalar(std_y):
+        std_y = numpy.array((std_y,))
 
     numpy.divide(r, std_x[:, numpy.newaxis], out=r)
     numpy.divide(r, std_y[numpy.newaxis, :], out=r)

--- a/cmapPy/math/tests/test_fast_corr.py
+++ b/cmapPy/math/tests/test_fast_corr.py
@@ -104,6 +104,23 @@ class TestFastCorr(unittest.TestCase):
         logger.debug("r:  {}".format(r))
         self.assertTrue(numpy.allclose(ex, r))
     
+    def test_fast_corr_1D_arrays(self):
+        logger.debug("*****************happy path test_fast_corr_1D_arrays")
+        x = numpy.array(range(3))
+        logger.debug("x.shape:  {}".format(x.shape))
+
+        r = fast_corr.fast_corr(x)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
+
+        y = numpy.array(range(3,6))
+        logger.debug("y.shape:  {}".format(y.shape))
+
+        r = fast_corr.fast_corr(x, y)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
+
+        
     def test_fast_corr_x_and_y_different_shapes(self):
         logger.debug("*************happy path x and y different shapes")
         x, _ = TestFastCorr.build_standard_x_y()

--- a/cmapPy/math/tests/test_fast_cov.py
+++ b/cmapPy/math/tests/test_fast_cov.py
@@ -224,6 +224,22 @@ class TestFastCov(unittest.TestCase):
         self.assertIs(dest, r)
         self.assertTrue(numpy.allclose(ex, dest))
 
+    def test_fast_cov_1D_arrays(self):
+        logger.debug("*****************happy path test_fast_cov_1D_arrays")
+        x = numpy.array(range(3))
+        logger.debug("x.shape:  {}".format(x.shape))
+
+        r = fast_cov.fast_cov(x)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
+
+        y = numpy.array(range(3,6))
+        logger.debug("y.shape:  {}".format(y.shape))
+
+        r = fast_cov.fast_cov(x, y)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
+
     def test_calculate_non_mask_overlaps(self):
         x = numpy.zeros((3,3))
         x[0,1] = numpy.nan
@@ -367,8 +383,23 @@ class TestFastCov(unittest.TestCase):
         r = fast_cov.nan_fast_cov(x)
         logger.debug("r:\n{}".format(r))
         
-        self.assertEqual(1, numpy.sum(numpy.isnan(r)))
+        self.assertEqual(0, numpy.sum(numpy.isnan(r)))
         
+    def test_nan_fast_cov_1D_arrays(self):
+        logger.debug("*****************happy path test_nan_fast_cov_1D_arrays")
+        x = numpy.array(range(3))
+        logger.debug("x.shape:  {}".format(x.shape))
+
+        r = fast_cov.nan_fast_cov(x)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
+
+        y = numpy.array(range(3,6))
+        logger.debug("y.shape:  {}".format(y.shape))
+
+        r = fast_cov.fast_cov(x, y)
+        logger.debug("r:  {}".format(r))
+        self.assertEqual(1., r[0][0])
         
 if __name__ == "__main__":
     setup_logger.setup(verbose=True)


### PR DESCRIPTION
I enhanced the fast_corr.fast_corr and related methods so they can accept 1D arrays as inputs (previously it would throw an exception - required a 2D array, workaround previously was to make the 2nd dimension size 1).